### PR TITLE
create safari classes for printing

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Freckle Certificates</title>
-    <link rel="icon" href="./favicon.ico">
+    <link rel="icon" href="./favicon.ico" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <link rel="stylesheet" type="text/css" href="styles-us.css" />
     <script>
       function showIt(elementId) {
-        var el = document.getElementById(elementId);
-        el.scrollIntoView({ behavior: "smooth", block: "start" });
-        return false;
+        var el = document.getElementById(elementId)
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        return false
       }
     </script>
   </head>
@@ -28,11 +28,13 @@
       </figure>
     </header>
 
-
     <main>
       <div id="menu" class="menu-section -no-print">
         <aside id="safari-note" class="-hidden">
-          <p>Certificates may not print well using the Safari browser. For the best results, please print on the latest version of the Chrome browser.</p>
+          <p>
+            For the best results, select the “landscape” orientation in your
+            print settings.
+          </p>
         </aside>
         <div class="title-section">
           <h1 class="page-title">Freckle Certificates</h1>
@@ -208,11 +210,7 @@
         <div class="cert-header -no-print">
           <h2>Great Work</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -273,11 +271,7 @@
         <div class="cert-header -no-print">
           <h2>Buen Trabajo</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -340,11 +334,7 @@
         <div class="cert-header -no-print">
           <h2>Great Progress</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -405,11 +395,7 @@
         <div class="cert-header -no-print">
           <h2>Gran Progreso</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -472,11 +458,7 @@
         <div class="cert-header -no-print">
           <h2>Questions Answered Correctly</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -546,11 +528,7 @@
         <div class="cert-header -no-print">
           <h2>Preguntas Respondidas Correctamente</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -622,11 +600,7 @@
         <div class="cert-header -no-print">
           <h2>Minutes Practiced</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -696,11 +670,7 @@
         <div class="cert-header -no-print">
           <h2>Minutos Practicados</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -772,11 +742,7 @@
         <div class="cert-header -no-print">
           <h2>Amazing Accuracy</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -845,11 +811,7 @@
         <div class="cert-header -no-print">
           <h2>Premio de Exactitud Asombrosa</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -920,11 +882,7 @@
         <div class="cert-header -no-print">
           <h2>Weekly Goal</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg
@@ -985,11 +943,7 @@
         <div class="cert-header -no-print">
           <h2>Meta Semanal</h2>
           <div class="print -no-print">
-            <button
-              type="button"
-              name="print"
-              class="print-button"
-            >
+            <button type="button" name="print" class="print-button">
               <span color="print-span">
                 <span class="icon-span">
                   <svg

--- a/_site/javascript.js
+++ b/_site/javascript.js
@@ -3,44 +3,44 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
   /* Hide all certificates except the one that was clicked */
   function printSingleCertificate(event) {
-    const currentCertificate = event.target.closest('.certificate')
-    const isSafari = userAgentIsSafari()
+    const currentCertificate = event.target.closest('.certificate');
+    const isSafari = userAgentIsSafari();
 
     document.querySelectorAll('.certificate').forEach((certificate) => {
       if (certificate !== currentCertificate) {
-        certificate.classList.add('-no-print')
+        certificate.classList.add('-no-print');
       } else if (isSafari) {
-        certificate.classList.add('safari-print-single')
+        certificate.classList.add('safari-print-single');
       }
-    })
+    });
 
-    window.print()
+    window.print();
   }
 
   /* Add a note to Safari users and Safari class on certificate frames */
   function addSafariNote() {
-    const isSafari = userAgentIsSafari()
+    const isSafari = userAgentIsSafari();
 
     if (isSafari) {
-      document.querySelector('#safari-note').classList.remove('-hidden')
+      document.querySelector('#safari-note').classList.remove('-hidden');
       document
         .querySelectorAll('.cert-frame')
-        .forEach((el) => el.classList.add('safari'))
+        .forEach((el) => el.classList.add('safari'));
     }
   }
 
   /* Check if user is using Safari */
   function userAgentIsSafari() {
-    const userAgent = navigator.userAgent
+    const userAgent = navigator.userAgent;
 
     /* Please see table:
      * https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name_and_version
      */
-    const containsSafari = userAgent.includes('Safari')
-    const containsChrome = userAgent.includes('Chrome')
-    const containsChromium = userAgent.includes('Chromium')
+    const containsSafari = userAgent.includes('Safari');
+    const containsChrome = userAgent.includes('Chrome');
+    const containsChromium = userAgent.includes('Chromium');
 
-    return containsSafari && !containsChrome && !containsChromium
+    return containsSafari && !containsChrome && !containsChromium;
   }
 
   /* END FUNCTION DECLARATIONS */
@@ -50,16 +50,16 @@ window.addEventListener('DOMContentLoaded', (event) => {
   /* Grab all "Print" buttons and add an event listener */
   document
     .querySelectorAll('.cert-header button')
-    .forEach((el) => el.addEventListener('click', printSingleCertificate))
+    .forEach((el) => el.addEventListener('click', printSingleCertificate));
 
   /* Undo the hiding of certificates after printing */
   window.addEventListener('afterprint', () => {
     document.querySelectorAll('.certificate').forEach((certificate) => {
-      certificate.classList.remove('-no-print')
-      certificate.classList.remove('safari-print-single')
-    })
-  })
+      certificate.classList.remove('-no-print');
+      certificate.classList.remove('safari-print-single');
+    });
+  });
 
   /* Add a note to Safari users */
-  addSafariNote()
-})
+  addSafariNote();
+});

--- a/_site/javascript.js
+++ b/_site/javascript.js
@@ -3,35 +3,35 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
   /* Hide all certificates except the one that was clicked */
   function printSingleCertificate(event) {
-    const currentCertificate = event.target.closest('.certificate');
+    const currentCertificate = event.target.closest('.certificate')
 
     document.querySelectorAll('.certificate').forEach((certificate) => {
       if (certificate !== currentCertificate) {
-        certificate.classList.add('-no-print');
+        certificate.classList.add('-no-print')
       } else {
-        certificate.classList.add('safari-print-single');
+        certificate.classList.add('safari-print-single')
       }
-    });
+    })
 
-    window.print();
+    window.print()
   }
 
   /* Add a note to Safari users */
   function addSafariNote() {
-    const userAgent = navigator.userAgent;
+    const userAgent = navigator.userAgent
 
     /* Please see table: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name_and_version */
-    const containsSafari = userAgent.includes('Safari');
-    const containsChrome = userAgent.includes('Chrome');
-    const containsChromium = userAgent.includes('Chromium');
+    const containsSafari = userAgent.includes('Safari')
+    const containsChrome = userAgent.includes('Chrome')
+    const containsChromium = userAgent.includes('Chromium')
 
-    const isSafari = containsSafari && !containsChrome && !containsChromium;
+    const isSafari = containsSafari && !containsChrome && !containsChromium
 
     if (isSafari) {
-      document.querySelector('#safari-note').classList.remove('-hidden');
+      document.querySelector('#safari-note').classList.remove('-hidden')
       document
         .querySelectorAll('.cert-frame')
-        .forEach((el) => el.classList.add('safari'));
+        .forEach((el) => el.classList.add('safari'))
     }
   }
 
@@ -42,16 +42,16 @@ window.addEventListener('DOMContentLoaded', (event) => {
   /* Grab all "Print" buttons and add an event listener */
   document
     .querySelectorAll('.cert-header button')
-    .forEach((el) => el.addEventListener('click', printSingleCertificate));
+    .forEach((el) => el.addEventListener('click', printSingleCertificate))
 
   /* Undo the hiding of certificates after printing */
   window.addEventListener('afterprint', () => {
     document.querySelectorAll('.certificate').forEach((certificate) => {
-      certificate.classList.remove('-no-print');
-      certificate.classList.remove('safari-print-single');
-    });
-  });
+      certificate.classList.remove('-no-print')
+      certificate.classList.remove('safari-print-single')
+    })
+  })
 
   /* Add a note to Safari users */
-  addSafariNote();
-});
+  addSafariNote()
+})

--- a/_site/javascript.js
+++ b/_site/javascript.js
@@ -1,17 +1,19 @@
-window.addEventListener("DOMContentLoaded", (event) => {
+window.addEventListener('DOMContentLoaded', (event) => {
   /* FUNCTION DECLARATIONS */
 
   /* Hide all certificates except the one that was clicked */
   function printSingleCertificate(event) {
     const currentCertificate = event.target.closest('.certificate');
 
-    document.querySelectorAll('.certificate').forEach(certificate => {
+    document.querySelectorAll('.certificate').forEach((certificate) => {
       if (certificate !== currentCertificate) {
         certificate.classList.add('-no-print');
+      } else {
+        certificate.classList.add('safari-print-single');
       }
-    })
+    });
 
-    window.print()
+    window.print();
   }
 
   /* Add a note to Safari users */
@@ -23,10 +25,13 @@ window.addEventListener("DOMContentLoaded", (event) => {
     const containsChrome = userAgent.includes('Chrome');
     const containsChromium = userAgent.includes('Chromium');
 
-    const isSafari = containsSafari && !containsChrome && !containsChromium
+    const isSafari = containsSafari && !containsChrome && !containsChromium;
 
     if (isSafari) {
       document.querySelector('#safari-note').classList.remove('-hidden');
+      document
+        .querySelectorAll('.cert-frame')
+        .forEach((el) => el.classList.add('safari'));
     }
   }
 
@@ -35,16 +40,17 @@ window.addEventListener("DOMContentLoaded", (event) => {
   /* FUNCTION CALLS */
 
   /* Grab all "Print" buttons and add an event listener */
-  document.querySelectorAll('.cert-header button').forEach(el =>
-    el.addEventListener('click', printSingleCertificate)
-  ) ;
+  document
+    .querySelectorAll('.cert-header button')
+    .forEach((el) => el.addEventListener('click', printSingleCertificate));
 
   /* Undo the hiding of certificates after printing */
   window.addEventListener('afterprint', () => {
-    document.querySelectorAll('.certificate').forEach(certificate => {
-        certificate.classList.remove('-no-print');
-    })
-  })
+    document.querySelectorAll('.certificate').forEach((certificate) => {
+      certificate.classList.remove('-no-print');
+      certificate.classList.remove('safari-print-single');
+    });
+  });
 
   /* Add a note to Safari users */
   addSafariNote();

--- a/_site/javascript.js
+++ b/_site/javascript.js
@@ -1,40 +1,46 @@
-window.addEventListener("DOMContentLoaded", (event) => {
+window.addEventListener('DOMContentLoaded', (event) => {
   /* FUNCTION DECLARATIONS */
 
   /* Hide all certificates except the one that was clicked */
   function printSingleCertificate(event) {
-    const currentCertificate = event.target.closest(".certificate");
+    const currentCertificate = event.target.closest('.certificate')
+    const isSafari = userAgentIsSafari()
 
-    document.querySelectorAll(".certificate").forEach((certificate) => {
+    document.querySelectorAll('.certificate').forEach((certificate) => {
       if (certificate !== currentCertificate) {
-        certificate.classList.add("-no-print");
-      } else {
-        certificate.classList.add("safari-print-single");
+        certificate.classList.add('-no-print')
+      } else if (isSafari) {
+        certificate.classList.add('safari-print-single')
       }
-    });
+    })
 
-    window.print();
+    window.print()
   }
 
-  /* Add a note to Safari users */
+  /* Add a note to Safari users and Safari class on certificate frames */
   function addSafariNote() {
-    const userAgent = navigator.userAgent;
+    const isSafari = userAgentIsSafari()
+
+    if (isSafari) {
+      document.querySelector('#safari-note').classList.remove('-hidden')
+      document
+        .querySelectorAll('.cert-frame')
+        .forEach((el) => el.classList.add('safari'))
+    }
+  }
+
+  /* Check if user is using Safari */
+  function userAgentIsSafari() {
+    const userAgent = navigator.userAgent
 
     /* Please see table:
      * https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#browser_name_and_version
      */
-    const containsSafari = userAgent.includes("Safari");
-    const containsChrome = userAgent.includes("Chrome");
-    const containsChromium = userAgent.includes("Chromium");
+    const containsSafari = userAgent.includes('Safari')
+    const containsChrome = userAgent.includes('Chrome')
+    const containsChromium = userAgent.includes('Chromium')
 
-    const isSafari = containsSafari && !containsChrome && !containsChromium;
-
-    if (isSafari) {
-      document.querySelector("#safari-note").classList.remove("-hidden");
-      document
-        .querySelectorAll(".cert-frame")
-        .forEach((el) => el.classList.add("safari"));
-    }
+    return containsSafari && !containsChrome && !containsChromium
   }
 
   /* END FUNCTION DECLARATIONS */
@@ -43,17 +49,17 @@ window.addEventListener("DOMContentLoaded", (event) => {
 
   /* Grab all "Print" buttons and add an event listener */
   document
-    .querySelectorAll(".cert-header button")
-    .forEach((el) => el.addEventListener("click", printSingleCertificate));
+    .querySelectorAll('.cert-header button')
+    .forEach((el) => el.addEventListener('click', printSingleCertificate))
 
   /* Undo the hiding of certificates after printing */
-  window.addEventListener("afterprint", () => {
-    document.querySelectorAll(".certificate").forEach((certificate) => {
-      certificate.classList.remove("-no-print");
-      certificate.classList.remove("safari-print-single");
-    });
-  });
+  window.addEventListener('afterprint', () => {
+    document.querySelectorAll('.certificate').forEach((certificate) => {
+      certificate.classList.remove('-no-print')
+      certificate.classList.remove('safari-print-single')
+    })
+  })
 
   /* Add a note to Safari users */
-  addSafariNote();
-});
+  addSafariNote()
+})

--- a/_site/styles.css
+++ b/_site/styles.css
@@ -2,11 +2,11 @@
  * Effra
  */
 @font-face {
-  font-family: "Effra";
+  font-family: 'Effra';
   font-weight: normal;
   font-style: normal;
-  src: local("Effra"), url("./fonts/Effra_W_Rg.woff2") format("woff2"),
-    url("./fonts/Effra_W_Rg.woff") format("woff");
+  src: local('Effra'), url('./fonts/Effra_W_Rg.woff2') format('woff2'),
+    url('./fonts/Effra_W_Rg.woff') format('woff');
 }
 
 /*
@@ -17,9 +17,9 @@
   font-weight: 300;
   font-style: normal;
   font-display: swap;
-  src: local("Nunito Regular"), local("Nunito-Regular"),
-    url("./fonts/nunito-regular.woff2") format("woff2"),
-    url("./fonts/nunito-regular.woff") format("woff");
+  src: local('Nunito Regular'), local('Nunito-Regular'),
+    url('./fonts/nunito-regular.woff2') format('woff2'),
+    url('./fonts/nunito-regular.woff') format('woff');
 }
 
 @font-face {
@@ -27,9 +27,9 @@
   font-weight: 600;
   font-style: normal;
   font-display: swap;
-  src: local("Nunito Bold"), local("Nunito-Bold"),
-    url("./fonts/nunito-bold.woff2") format("woff2"),
-    url("./fonts/nunito-bold.woff") format("woff");
+  src: local('Nunito Bold'), local('Nunito-Bold'),
+    url('./fonts/nunito-bold.woff2') format('woff2'),
+    url('./fonts/nunito-bold.woff') format('woff');
 }
 
 /* var */
@@ -37,8 +37,8 @@
   --blue: #2e95d2;
   --pink: #f15c5c;
   --green: #00a38f;
-  --font1: "Nunito";
-  --font2: "Effra";
+  --font1: 'Nunito';
+  --font2: 'Effra';
 }
 html {
   margin: 0;
@@ -154,22 +154,22 @@ header > figure {
 }
 /* TODO: Remove this once we get en-gb working */
 #cert-1-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-great_work.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-great_work.svg');
 }
 #cert-2-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-great_progress.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-great_progress.svg');
 }
 #cert-3-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-questions_answered.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-questions_answered.svg');
 }
 #cert-4-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-minutes_practiced.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-minutes_practiced.svg');
 }
 #cert-5-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-accuracy.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-accuracy.svg');
 }
 #cert-6-menu .menu-svg {
-  background-image: url("certificate-menu-images/Freckle-certificates-menu-v1-weekly_goal.svg");
+  background-image: url('certificate-menu-images/Freckle-certificates-menu-v1-weekly_goal.svg');
 }
 /* END TODO */
 
@@ -374,22 +374,22 @@ hr.break {
 /* Certificate SVG */
 /* English */
 #cert-1 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-great_work.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-great_work.svg');
 }
 #cert-2 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-great_progress.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-great_progress.svg');
 }
 #cert-3 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-questions_answered.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-questions_answered.svg');
 }
 #cert-4 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-minutes_practiced.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-minutes_practiced.svg');
 }
 #cert-5 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-accuracy.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-accuracy.svg');
 }
 #cert-6 {
-  background-image: url("certificate-art/Freckle-certificates-letter-v1-weekly_goal.svg");
+  background-image: url('certificate-art/Freckle-certificates-letter-v1-weekly_goal.svg');
 }
 
 /* #cert-1 */
@@ -850,7 +850,7 @@ hr.break {
   }
 
   .safari-print-single .cert-frame {
-    height: 7.43in !important;
+    height: 7.43in;
   }
 
   /* Copyrights */

--- a/_site/styles.css
+++ b/_site/styles.css
@@ -838,4 +838,228 @@ hr.break {
     /* Internet Explorer 10+ */
     color: transparent;
   }
+
+  /* General Safari Print Rules */
+
+  .safari {
+    height: 7.56in;
+    margin: 0;
+    page-break-before: avoid;
+    page-break-after: avoid;
+    page-break-inside: avoid;
+  }
+
+  .safari-print-single .cert-frame {
+    height: 7.43in !important;
+  }
+
+  /* Copyrights */
+
+  .safari .copyright {
+    top: 650px;
+    left: 160px;
+  }
+
+  /* Cert 1 */
+
+  .safari#cert-1 .to-label,
+  .safari#cert-1-esp .to-label {
+    top: 273px;
+    left: 143px;
+  }
+  .safari#cert-1 .-f2,
+  .safari#cert-1-esp .-f2 {
+    top: 275px;
+  }
+  .safari#cert-1 .-f3,
+  .safari#cert-1-esp .-f3 {
+    top: 370px;
+  }
+  .safari#cert-1 .-f4,
+  .safari#cert-1-esp .-f4 {
+    top: 420px;
+  }
+  .safari#cert-1 .form-group,
+  .safari#cert-1-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-1 .date-group,
+  .safari#cert-1-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-1 .from-group,
+  .safari#cert-1-esp .from-group {
+    left: 585px;
+  }
+
+  /* Cert 2 */
+
+  .safari#cert-2 .to-label,
+  .safari#cert-2-esp .to-label {
+    top: 285px;
+  }
+  .safari#cert-2 .-f2,
+  .safari#cert-2-esp .-f2 {
+    top: 300px;
+  }
+  .safari#cert-2 .-f3,
+  .safari#cert-2-esp .-f3 {
+    top: 390px;
+  }
+  .safari#cert-2 .-f4,
+  .safari#cert-2-esp .-f4 {
+    top: 420px;
+  }
+  .safari#cert-2 .form-group,
+  .safari#cert-2-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-2 .date-group,
+  .safari#cert-2-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-2 .from-group,
+  .safari#cert-2-esp .from-group {
+    left: 585px;
+  }
+
+  /* Cert 3 */
+
+  .safari#cert-3 .-f1,
+  .safari#cert-3-esp .-f1 {
+    top: 100px;
+  }
+  .safari#cert-3 .-f2,
+  .safari#cert-3-esp .-f2 {
+    top: 210px;
+  }
+  .safari#cert-3 .for-label,
+  .safari#cert-3-esp .for-label {
+    top: 285px;
+    left: 407px;
+  }
+  .safari#cert-3 .-f3,
+  .safari#cert-3-esp .-f3 {
+    top: 305px;
+  }
+  .safari#cert-3 .-f4,
+  .safari#cert-3-esp .-f4 {
+    top: 410px;
+  }
+  .safari#cert-3 .form-group,
+  .safari#cert-3-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-3 .date-group,
+  .safari#cert-3-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-3 .from-group,
+  .safari#cert-3-esp .from-group {
+    left: 585px;
+  }
+
+  /* Cert 4 */
+
+  .safari#cert-4 .-f1,
+  .safari#cert-4-esp .-f1 {
+    top: 90px;
+  }
+  .safari#cert-4 .-f2,
+  .safari#cert-4-esp .-f2 {
+    top: 210px;
+  }
+  .safari#cert-4 .for-label,
+  .safari#cert-4-esp .for-label {
+    top: 285px;
+    left: 407px;
+  }
+  .safari#cert-4 .-f3,
+  .safari#cert-4-esp .-f3 {
+    top: 315px;
+  }
+  .safari#cert-4 .-f4,
+  .safari#cert-4-esp .-f4 {
+    top: 410px;
+  }
+  .safari#cert-4 .form-group,
+  .safari#cert-4-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-4 .date-group,
+  .safari#cert-4-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-4 .from-group,
+  .safari#cert-4-esp .from-group {
+    left: 585px;
+  }
+
+  /* Cert 5 */
+
+  .safari#cert-5 .-f2,
+  .safari#cert-5-esp .-f2 {
+    top: 280px;
+  }
+  .safari#cert-5 .-f3,
+  .safari#cert-5-esp .-f3 {
+    top: 380px;
+  }
+  .safari#cert-5 .-f4,
+  .safari#cert-5-esp .-f4 {
+    top: 475px;
+  }
+  .safari#cert-5 .form-group,
+  .safari#cert-5-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-5 .date-group,
+  .safari#cert-5-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-5 .from-group,
+  .safari#cert-5-esp .from-group {
+    left: 585px;
+  }
+  .safari#cert-5 .copyright,
+  .safari#cert-5-esp .copyright {
+    top: 660px;
+    left: 120px;
+  }
+
+  /* Cert 6 */
+
+  .safari#cert-6 .-f1,
+  .safari#cert-6-esp .-f1 {
+    top: 100px;
+  }
+  .safari#cert-6 .-f2,
+  .safari#cert-6-esp .-f2 {
+    top: 190px;
+  }
+  .safari#cert-6 .for-label,
+  .safari#cert-6-esp .for-label {
+    top: 275px;
+  }
+  .safari#cert-6 .-f3,
+  .safari#cert-6-esp .-f3 {
+    top: 320px;
+    left: 15px;
+  }
+  .safari#cert-6 .-f4,
+  .safari#cert-6-esp .-f4 {
+    top: 410px;
+  }
+  .safari#cert-6 .form-group,
+  .safari#cert-6-esp .form-group {
+    top: 550px;
+  }
+  .safari#cert-6 .date-group,
+  .safari#cert-6-esp .date-group {
+    left: 185px;
+  }
+  .safari#cert-6 .from-group,
+  .safari#cert-6-esp .from-group {
+    left: 585px;
+  }
 }


### PR DESCRIPTION
Added styling, so Safari users can print certificates properly.

The @page css selector is not supported by Safari, so the user must select landscape mode on printing. The styles added to fix the print involve removing page breaks and margins and setting a height.

A different height is necessary when printing single pages to prevent an empty 2nd page, so a safari-print-single class is added at the same time as the -no-print classes.

Otherwise, the remaining changes are adjust the top and left values to properly position the text.